### PR TITLE
Histogram

### DIFF
--- a/JAG3D/src/org/applied_geodesy/jag3d/sql/SQLManager.java
+++ b/JAG3D/src/org/applied_geodesy/jag3d/sql/SQLManager.java
@@ -5007,6 +5007,7 @@ public class SQLManager {
 				+ "ON \"ObservationGroup\".\"id\" = \"ObservationApriori\".\"group_id\" "
 				+ "WHERE \"ObservationGroup\".\"enable\" = TRUE "
 				+ "AND \"ObservationApriori\".\"enable\" = TRUE "
+				+ "AND \"redundancy\" > 0 "
 				+ "AND \"type\" IN (" + inArrayValues + ") "
 				+ "ORDER BY \"normalized_residual\" ASC";
 


### PR DESCRIPTION
- exclude data in plot having no redundancy to avoid confusions
- check the `binWidth` against zero to avoid division by zero