### PR TITLE
Open Report System Application

### DIFF
--- a/JAG3D/src/org/applied_geodesy/coordtrans/ui/io/writer/FTLReport.java
+++ b/JAG3D/src/org/applied_geodesy/coordtrans/ui/io/writer/FTLReport.java
@@ -137,7 +137,7 @@ public class FTLReport {
 		this.addEulerAngles();
 	}
 	
-	public void toFile(File report) throws ClassNotFoundException, TemplateException, IOException {
+	public void toFile(File report, boolean openFile) throws ClassNotFoundException, TemplateException, IOException {
 		if (report != null) {
 			this.createReport();
 			Writer file = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(report), StandardCharsets.UTF_8));
@@ -145,7 +145,7 @@ public class FTLReport {
 			file.flush();
 			file.close();
 
-			if (hostServices != null)
+			if (hostServices != null && openFile)
 				hostServices.showDocument(report.getAbsolutePath());
 		}
 	}

--- a/JAG3D/src/org/applied_geodesy/coordtrans/ui/menu/UIMenuBuilder.java
+++ b/JAG3D/src/org/applied_geodesy/coordtrans/ui/menu/UIMenuBuilder.java
@@ -358,12 +358,14 @@ public class UIMenuBuilder implements TransformationChangeListener {
 			if (UITreeBuilder.getInstance().getTransformationAdjustment().getTransformation() == null)
 				return;
 
-			Pattern pattern = Pattern.compile(".*?\\.(\\w+)\\.ftlh$", Pattern.CASE_INSENSITIVE);
+			Pattern pattern = Pattern.compile(".*?\\.(\\.)?(\\w+)\\.ftlh$", Pattern.CASE_INSENSITIVE);
 			Matcher matcher = pattern.matcher(templateFile.getName().toLowerCase());
 			String extension = "html";
+			boolean openFileInSystemApplication = true;
 			ExtensionFilter extensionFilter = new ExtensionFilter(i18n.getString("UIMenuBuilder.report.extension.html", "Hypertext Markup Language"), "*.html", "*.htm", "*.HTML", "*.HTM");
 			if (matcher.find() && matcher.groupCount() == 1) {
-				extension = matcher.group(1);
+				openFileInSystemApplication = matcher.group(1) == null;
+				extension = matcher.group(2);
 				extensionFilter = new ExtensionFilter(String.format(Locale.ENGLISH, i18n.getString("UIMenuBuilder.report.extension.template", "%s-File"), extension), "*." + extension); 
 			}
 			
@@ -378,7 +380,7 @@ public class UIMenuBuilder implements TransformationChangeListener {
 			);
 			if (reportFile != null && ftl != null) {
 				ftl.setTemplate(templateFile.getName());
-				ftl.toFile(reportFile);
+				ftl.toFile(reportFile, openFileInSystemApplication);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/JAG3D/src/org/applied_geodesy/jag3d/ui/io/writer/report/FTLReport.java
+++ b/JAG3D/src/org/applied_geodesy/jag3d/ui/io/writer/report/FTLReport.java
@@ -156,7 +156,7 @@ public class FTLReport {
 		return this.dataBase != null ? this.dataBase.getURI() : null;
 	}
 
-	public void toFile(File report) throws ClassNotFoundException, SQLException, TemplateException, IOException {
+	public void toFile(File report, boolean openFile) throws ClassNotFoundException, SQLException, TemplateException, IOException {
 		if (report != null) {
 			this.createReport();
 			Writer file = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(report), StandardCharsets.UTF_8));
@@ -164,7 +164,7 @@ public class FTLReport {
 			file.flush();
 			file.close();
 
-			if (this.hostServices != null)
+			if (this.hostServices != null && openFile)
 				this.hostServices.showDocument(report.getAbsolutePath());
 		}
 	}

--- a/JAG3D/src/org/applied_geodesy/jag3d/ui/menu/UIMenuBuilder.java
+++ b/JAG3D/src/org/applied_geodesy/jag3d/ui/menu/UIMenuBuilder.java
@@ -1065,12 +1065,14 @@ public class UIMenuBuilder {
 	
 	void createReport(File templateFile) {
 		try {
-			Pattern pattern = Pattern.compile(".*?\\.(\\w+)\\.ftlh$", Pattern.CASE_INSENSITIVE);
+			Pattern pattern = Pattern.compile(".*?\\.(\\.)?(\\w+)\\.ftlh$", Pattern.CASE_INSENSITIVE);
 			Matcher matcher = pattern.matcher(templateFile.getName().toLowerCase());
 			String extension = "html";
+			boolean openFileInSystemApplication = true;
 			ExtensionFilter extensionFilter = new ExtensionFilter(i18n.getString("UIMenuBuilder.extension.html", "Hypertext Markup Language"), "*.html", "*.htm", "*.HTML", "*.HTM");
-			if (matcher.find() && matcher.groupCount() == 1) {
-				extension = matcher.group(1);
+			if (matcher.find() && matcher.groupCount() == 2) {
+				openFileInSystemApplication = matcher.group(1) == null;
+				extension = matcher.group(2);
 				extensionFilter = new ExtensionFilter(String.format(Locale.ENGLISH, i18n.getString("UIMenuBuilder.extension.template", "%s-File"), extension), "*." + extension); 
 			}
 
@@ -1094,7 +1096,7 @@ public class UIMenuBuilder {
 					);
 			if (reportFile != null && ftl != null) {
 				ftl.setTemplate(templateFile.getName());
-				ftl.toFile(reportFile);
+				ftl.toFile(reportFile, openFileInSystemApplication);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/JAG3D/src/org/applied_geodesy/juniform/io/writer/FTLReport.java
+++ b/JAG3D/src/org/applied_geodesy/juniform/io/writer/FTLReport.java
@@ -124,7 +124,7 @@ public class FTLReport {
 		this.addCorrelationMatrix();
 	}
 	
-	public void toFile(File report) throws ClassNotFoundException, TemplateException, IOException {
+	public void toFile(File report, boolean openFile) throws ClassNotFoundException, TemplateException, IOException {
 		if (report != null) {
 			this.createReport();
 			Writer fileWriter = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(report), StandardCharsets.UTF_8));
@@ -132,7 +132,7 @@ public class FTLReport {
 			fileWriter.flush();
 			fileWriter.close();
 
-			if (hostServices != null)
+			if (hostServices != null && openFile)
 				hostServices.showDocument(report.getAbsolutePath());
 		}
 	}

--- a/JAG3D/src/org/applied_geodesy/juniform/ui/menu/UIMenuBuilder.java
+++ b/JAG3D/src/org/applied_geodesy/juniform/ui/menu/UIMenuBuilder.java
@@ -569,12 +569,14 @@ public class UIMenuBuilder implements FeatureChangeListener {
 			if (UITreeBuilder.getInstance().getFeatureAdjustment().getFeature() == null)
 				return;
 
-			Pattern pattern = Pattern.compile(".*?\\.(\\w+)\\.ftlh$", Pattern.CASE_INSENSITIVE);
+			Pattern pattern = Pattern.compile(".*?\\.(\\.)?(\\w+)\\.ftlh$", Pattern.CASE_INSENSITIVE);
 			Matcher matcher = pattern.matcher(templateFile.getName().toLowerCase());
 			String extension = "html";
+			boolean openFileInSystemApplication = true;
 			ExtensionFilter extensionFilter = new ExtensionFilter(i18n.getString("UIMenuBuilder.report.extension.html", "Hypertext Markup Language"), "*.html", "*.htm", "*.HTML", "*.HTM");
 			if (matcher.find() && matcher.groupCount() == 1) {
-				extension = matcher.group(1);
+				openFileInSystemApplication = matcher.group(1) == null;
+				extension = matcher.group(2);
 				extensionFilter = new ExtensionFilter(String.format(Locale.ENGLISH, i18n.getString("UIMenuBuilder.report.extension.template", "%s-File"), extension), "*." + extension); 
 			}
 			
@@ -589,7 +591,7 @@ public class UIMenuBuilder implements FeatureChangeListener {
 			);
 			if (reportFile != null && ftl != null) {
 				ftl.setTemplate(templateFile.getName());
-				ftl.toFile(reportFile);
+				ftl.toFile(reportFile, openFileInSystemApplication);
 			}
 		} catch (Exception e) {
 			e.printStackTrace();


### PR DESCRIPTION
To prevent the report from being opened in the standard application, a dot can be added to the template name, e.g. `Template.txt.ftlh` opens a text editor, but  `Template..txt.ftlh` will not open the editor